### PR TITLE
Define EGL_NO_X11

### DIFF
--- a/src/glamor_egl.h
+++ b/src/glamor_egl.h
@@ -28,6 +28,7 @@
 #define GLAMOR_EGL_H
 
 #define MESA_EGL_NO_X11_HEADERS
+#define EGL_NO_X11
 #include <epoxy/gl.h>
 #include <epoxy/egl.h>
 

--- a/src/glamor_priv.h
+++ b/src/glamor_priv.h
@@ -39,6 +39,7 @@
 
 #include <epoxy/gl.h>
 #define MESA_EGL_NO_X11_HEADERS
+#define EGL_NO_X11
 #include <epoxy/egl.h>
 
 #ifdef GLAMOR_HAS_GBM


### PR DESCRIPTION
Define EGL_NO_X11 everywhere were we also define MESA_EGL_NO_X11_HEADERS,
EGL_NO_X11 is the MESA_EGL_NO_X11_HEADERS equivalent for the egl headers
shipped with libglvnd.